### PR TITLE
update dockerfile to use base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN apt install -y --no-install-recommends \
 COPY scripts/askpass.sh /usr/local/bin/askpass.sh
 
 FROM resource
-LABEL MAINTAINER=telia-oss
+LABEL MAINTAINER=cloud-gov


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates code to use our base hardened image
- This dockerfile used to live in the common-pipelines repo, but now that we fork this repo it can live here

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Use the hardened base image
