### PR TITLE
update teams for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloud-gov/platform-ops

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default. Unless we have a more specific match.
-*       @telia-oss/golang


### PR DESCRIPTION
## Changes proposed in this pull request:

- update teams for CODEOWNERS

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates the CODEOWNERS for this repo to only reference GitHub teams within this organization
